### PR TITLE
Indica local ideal da divisão

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -24,7 +24,7 @@ namespace JurosSimples
             Console.WriteLine();
             Console.WriteLine("---------------------");
 
-            juros = c * i * t *1 /100 ;
+            juros = c * (i / 100) * t ;
             mont = c + juros;
             Console.WriteLine($"\nJuros (R$)....: {juros:N2}");
             Console.WriteLine($"Montante(R$)..: {mont:N2}");


### PR DESCRIPTION
Neste caso, a divisão no final da operação dará certo, porém, esta divisão pertence à taxa, que é informada pelo usuário em % e para o cálculo, precisa ser colocada em "por cento" (i/100)